### PR TITLE
Add new category for systems which orchestrates workflow runs by other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Workflow platforms
 * [Wings](http://www.wings-workflows.org) - Semantic workflow system utilizing Pegasus as execution system.
 * [Watchdog](https://github.com/klugem/watchdog) - Workflow management system for the automated and distributed analysis of large-scale experimental data.
 
+Workflow orchestration systems
+------------------------------
+* [Arteria](https://arteria-project.github.io/) - Event-driven sequencing center automation, which initiates workflows based on events.
+
 Workflow languages 
 -------------------
 * [Common Workflow Language](https://github.com/common-workflow-language/common-workflow-language)


### PR DESCRIPTION
[Arteria](https://arteria-project.github.io/) is a system that does not implement a workflow engine by itself, but which does event-driven workflow initiation of workflows written in other tools.

This seems like it might need a new category.