### PR TITLE
Add Ray

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Pipeline frameworks & libraries
 * [Qdo](https://bitbucket.org/berkeleylab/qdo) - Lightweight high-throughput queuing system for workflows with many small tasks to perform.
 * [Qsubsec](https://github.com/alastair-droop/qsubsec) - Simple tokenised template system for SGE.
 * [Rabix](https://github.com/rabix/rabix) - Python-based workflow toolkit based on the Common Workflow Language and Docker.
+* [Ray](https://github.com/ray-project/ray) - Flexible, high-performance distributed Python execution framework.
 * [Reflow](https://github.com/grailbio/reflow) - Language and runtime for distributed, incremental data processing in the cloud.
 * [Remake](https://github.com/richfitz/remake) - Make-like declarative workflows in R.
 * [Rmake](http://physiology.med.cornell.edu/faculty/mason/lab/r-make/) - Wrapper for the creation of Makefiles, enabling massive parallelization.


### PR DESCRIPTION
Ray is another missing one. It is for Python, a competitor to Dask -- the project is going strong, and is the original author of the [(now Apache) Arrow data store](https://arrow.apache.org/).