### PR TITLE
Add ZnTrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Pipeline frameworks & libraries
 * [WorldMake](http://worldmake.org/) - Easy Collaborative Reproducible Computing.
 * [Zenaton](https://zenaton.com) - Workflow engine for orchestrating jobs, data and events across your applications and third party services.
 * [ZenML](https://zenml.io) - Extensible open-source MLOps framework to create reproducible pipelines for data scientists.
+* [ZnTrack](https://github.com/zincware/ZnTrack) - Workflow and Experiment Management in Python based on DVC.
 
 Workflow platforms
 --------------------


### PR DESCRIPTION
The  [ZnTrack](https://github.com/zincware/ZnTrack) package provides workflow and Experiment management based on [DVC](https://dvc.org/).
It can be used to
- build graphs from within Python
- write packages that can be used as nodes on other graphs built around DVC.

# API
A ZnTrack Node is similar to the dataclass API, defining inputs, outputs and the node methods in an object oriented approach:

```python
class InputToOutput(Node):
    """Save the inputs 'zn.params' to the outputs attribute 'zn.outs'"""

    inputs = zn.params()
    outputs = zn.outs()

    def run(self):
        self.outputs = self.inputs
```

Nodes can be connected via `zn.deps(InputToOutput)` or the respective files that are generated.
More examples are available at https://github.com/zincware/znlib which collects ZnTrack Nodes and is constantly growing.
