### PR TITLE
Remove link to Biokepler website

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Workflow platforms
 * [Apache Iravata](https://airavata.apache.org/) - Framework for executing and managing computational workflows on distributed computing resources.
 * [Arteria](https://arteria-project.github.io/) - Event-driven automation for sequencing centers. Initiates workflows based on events.
 * [Arvados](http://arvados.org) - A container based workflow platform.
-* [Biokepler](http://www.biokepler.org) - Bioinformatics Scientific Workflow for Distributed Analysis of Large-Scale Biological Data.
+* Biokepler - Bioinformatics Scientific Workflow for Distributed Analysis of Large-Scale Biological Data. ([_inactive since 10/2019_](https://web.archive.org/web/20190108162953/https://www.biokepler.org/))
 * [Butler](http://github.com/llevar/butler) - Framework for running scientific workflows on public and academic clouds.
 * [Chipster](http://chipster.csc.fi) - Open source platform for data analysis.
 * [Clubber](https://bitbucket.org/bromberglab/clubber) - Cluster Load Balancer for Bioinformatics e-Resources.


### PR DESCRIPTION
Biokepler is apparently inactive since late 2019, since then domain points to a spam/advertisement Wordpress site.