### PR TITLE
Add Anvi’o metagenomics community and framework.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Pipeline frameworks & libraries
 Workflow platforms
 --------------------
 * [ActivePapers](http://www.activepapers.org/) - Computational science made reproducible and publishable.
+* [Anvi’o](https://anvio.org/) - A community and framework centered around metagenomics, designed to facilitate reproducible exploration and visualization of data.
 * [Apache Iravata](https://airavata.apache.org/) - Framework for executing and managing computational workflows on distributed computing resources.
 * [Arteria](https://arteria-project.github.io/) - Event-driven automation for sequencing centers. Initiates workflows based on events.
 * [Arvados](http://arvados.org) - A container based workflow platform.


### PR DESCRIPTION
This PR adds Anvi’o, a metagenomics community and framework. The original Anvi’o publication is from 2015, an update was published in 2021: 

> _Eren AM, Esen ÖC, Quince C, Vineis JH, Morrison HG, Sogin ML, Delmont TO_: Anvi’o: an advanced analysis and visualization platform for ‘omics data. **PeerJ** 3:e1319 (2015) [https://doi.org/10.7717/peerj.1319](https://peerj.com/articles/1319/)


> _Eren, A.M., Kiefl, E., Shaiber, A. et al._ Community-led, integrated, reproducible multi-omics with anvi’o. **Nat Microbiol** 6, 3–6 (2021). [https://doi.org/10.1038/s41564-020-00834-3](https://www.nature.com/articles/s41564-020-00834-3)



Exemplary third-party studies which reference Anvi’o are:

> _Taş N, de Jong A., Li Y., Trubl G., Xue Y., Dove NC._: Metagenomic tools in microbial ecology research. **Current Opinion in Biotechnology** 67, 184-191 (2021) [https://doi.org/10.1016/j.copbio.2021.01.019](https://www.sciencedirect.com/science/article/pii/S0958166921000240)

> _Gaïa, M., Meng, L., Pelletier, E. et al._ Mirusviruses link herpesviruses to giant viruses. **Nature** 616, 783–789 (2023). [https://doi.org/10.1038/s41586-023-05962-4](https://www.nature.com/articles/s41586-023-05962-4)