### PR TITLE
Add Makeit

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Pipeline frameworks & libraries
 * [Kedro](https://github.com/quantumblacklabs/kedro) - Workflow development tool that helps you build data pipelines.
 * [Kestra](https://github.com/kestra-io/kestra) - Open source data orchestration and scheduling platform with declarative syntax.
 * [Ketrew](https://github.com/hammerlab/ketrew) - Embedded DSL in the OCAML language alongside a client-server management application.
-* [https://github.com/Nike-Inc/koheesio] - Python framework for building efficient data pipelines.
+* [Koheesio](https://github.com/Nike-Inc/koheesio) - Python framework for building efficient data pipelines.
 * [Kronos](https://github.com/jtaghiyar/kronos) - Workflow assembler for cancer genome analytics and informatics.
 * [Kubeflow Pipelines](https://www.kubeflow.org/docs/components/pipelines/) - Framework for building and deploying portable, scalable machine learning workflows using Docker containers and Argo Workflows.
 * [Loom](https://github.com/StanfordBioinformatics/loom) - Tool for running bioinformatics workflows locally or in the cloud.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Pipeline frameworks & libraries
 * [Luigi](https://github.com/spotify/luigi) - Python module that helps you build complex pipelines of batch jobs.
 * [Maestro](https://github.com/LLNL/maestrowf) - YAML based HPC workflow execution tool.
 * [Makeflow](http://ccl.cse.nd.edu/software/makeflow/) - Workflow engine for executing large complex workflows on clusters.
+* [Makeit](https://github.com/arni-magnusson/makeit) - Run R scripts if needed, based on last modified time.
 * [makepipe](https://github.com/kinto-b/makepipe) - An R package which provides a set of simple tools for transforming an existing workflow into a self-documenting pipeline with very minimal upfront costs.
 * [Mara](https://github.com/mara/data-integration) -  A lightweight, opinionated ETL framework, halfway between plain scripts and Apache Airflow.
 * [Mario](https://github.com/intentmedia/mario) - Scala library for defining data pipelines.


### PR DESCRIPTION
The [makeit](https://github.com/arni-magnusson/makeit) package provides the `make()` function that is (very) closely based on GNU Make.

As such, it provides the building block to construct a pipeline of arbitrary complexity, as described in the [vignette](https://cran.r-project.org/web/packages/makeit/vignettes/makeit.html). Similar to writing a makefile, one can organize `make()` declarations in a script called `_make.R` or the like. One can also include a `make()` call within a workflow to run computations in another script and `make()` will deduce whether that script needs to be run.

In short: `make()` runs an R script if underlying files have changed, otherwise it does nothing.