### PR TITLE
Add Velda to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Workflow platforms
 * [Domino](https://github.com/Tauffer-Consulting/domino) - User friendly and open source visual workflow management platform.
 * [Fireworks](https://github.com/materialsproject/fireworks) - Centralized workflow server for dynamic workflows of high-throughput computations.
 * [Flojoy](https://github.com/flojoy-ai/studio) - Open source visual Python scripting for test, measurement, and robotics control.
+* [FlowHub](https://www.flowhub.com.cn) - FlowHub is a new workflow cloud platform.
 * [Flyte](https://github.com/lyft/flyte) - Container-native, type-safe workflow and pipelines platform for large scale processing and ML.
 * [Galaxy](https://galaxyproject.org) - Powerful workflow system which can be used on the command line or with the GUI.
 * [Geoweaver](https://github.com/ESIPFed/Geoweaver) - In-browser tool for data processing workflows with high-performance server support, featuring code history and workflow orchestration.
@@ -173,14 +174,14 @@ Workflow platforms
 * [Polyaxon](https://github.com/polyaxon/polyaxon) - A platform for machine learning experimentation workflow.
 * [Reana](https://github.com/reanahub/reana) - Platform for reusable research data analyses developed by CERN.
 * [Sushi](https://github.com/uzh/sushi) - Supporting User for SHell script Integration.
-* [Yabi](http://ccg.murdoch.edu.au/yabi) - Online research environment for grid, HPC and cloud computing.
 * [Taverna](http://www.taverna.org.uk) - Domain independent workflow system.
 * [Temporal](https://www.temporal.io/) - Highly scalable developer oriented _Workflow as Code_ engine.
-* [Windmill](https://github.com/windmill-labs/windmill) - Developer platform and workflow engine to turn scripts into internal tools.
+* [Velda](https://velda.io) - Developer friendly workflow engine, define pipelines with simple shell commands.
 * [VisTrails](http://www.vistrails.org/) - Scientific workflow and provenance management system.
-* [Wings](http://www.wings-workflows.org) - Semantic workflow system utilizing Pegasus as execution system.
 * [Watchdog](https://github.com/klugem/watchdog) - Workflow management system for the automated and distributed analysis of large-scale experimental data.
-* [FlowHub](https://www.flowhub.com.cn) - FlowHub is a new workflow cloud platform.
+* [Windmill](https://github.com/windmill-labs/windmill) - Developer platform and workflow engine to turn scripts into internal tools.
+* [Wings](http://www.wings-workflows.org) - Semantic workflow system utilizing Pegasus as execution system.
+* [Yabi](http://ccg.murdoch.edu.au/yabi) - Online research environment for grid, HPC and cloud computing.
 
 Workflow languages
 -------------------


### PR DESCRIPTION
Velda allows developer to build pipeline without container build and can setup with simple syntax: [instruction](https://velda.io/blog/vrun-is-all-you-need#enterprise-grade-pipeline-orchestration) . Your dev-container is the "image" to run all jobs.

Also reorder list.