### PR TITLE
Add FailureMemory to Continuous Delivery workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Continuous Delivery workflows
 --------------------------------
 * [Argo](https://github.com/argoproj/argo) - Get stuff done with container-native workflows for Kubernetes.
 * [CDS](https://github.com/ovh/cds) - A pipeline based Continuous Delivery Service written in Golang.
+* [FailureMemory](https://github.com/UnguisAI/failurememory) - GitHub Action for recurring CI failure fingerprinting and memory-backed triage.
 
 Build automation tools
 ----------------------


### PR DESCRIPTION
## Summary

- add FailureMemory to the `Continuous Delivery workflows` section
- keep the section alphabetical

## Why

FailureMemory is a GitHub Action for recurring CI failure fingerprinting and memory-backed triage. It helps maintainers recognize repeated GitHub Actions failures and shorten re-triage work instead of re-reading the same CI noise from scratch.