### PR TITLE
Add hpc-slurm-lab to Other projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Other projects
 * [NiFi](https://nifi.apache.org) - Powerful and scalable directed graphs of data routing, transformation, and system mediation logic.
 * [noWorkflow](https://github.com/gems-uff/noworkflow) - Supporting infrastructure to run scientific experiments without a scientific workflow management system, and still get things like provenance.
 * [Reprozip](https://www.reprozip.org/) - Simplifies the process of creating reproducible experiments from command-line executions.
+* [hpc-slurm-lab](https://github.com/revengator/hpc-slurm-lab) - Minimal modern SLURM cluster on Docker Compose for local HPC and pipeline testing on a laptop. Includes Lmod and EasyBuild preinstalled, runs on Apple Silicon and Linux x86_64.
 
 
 Related lists


### PR DESCRIPTION
Adds hpc-slurm-lab — a minimal SLURM 25.05 cluster on Docker Compose for local HPC and pipeline testing on a laptop. Useful as a target environment for developing and testing pipelines (Nextflow, Snakemake, etc.) against a real SLURM scheduler without needing access to a remote cluster. Comes with Lmod + EasyBuild preinstalled, dynamic node registration, accounting (slurmdbd + MariaDB), and optional NVIDIA GPU support. Runs on Apple Silicon (arm64) and Linux x86_64.

Fits the Other projects section alongside HPC Grid Runner and noWorkflow as supporting infrastructure for running pipelines.

- Repo: https://github.com/revengator/hpc-slurm-lab
- DOI: https://doi.org/10.5281/zenodo.20368838
- License: MIT