### PR TITLE
Add Duckle to ETL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Extract, transform, load (ETL)
 * [Bruin](https://github.com/bruin-data/bruin) - Data pipeline framework supporting SQL and Python in the same DAG. Built-in data quality assertions, cross-database lineage, and incremental processing. Targets data warehouses (BigQuery, Snowflake, Postgres, etc.).
 * [Cadence](https://github.com/uber/cadence) Distributed, scalable, durable, and highly available orchestration engine developed by Uber.
 * [Dataform](https://github.com/dataform-co/dataform) - Dataform is a framework for managing SQL based operations in your data warehouse.
+* [Duckle](https://github.com/SouravRoy-ETL/duckle) - Open-source visual ETL/ELT studio that compiles a drag-and-drop canvas to DuckDB SQL, with 300+ connectors and a built-in MCP server.
 * [Hevo](https://hevodata.com/integrations/pipeline/) - Hevo is a Fully Automated, No-code Data Pipeline Platform that supports 150+ ready-to-use integrations across Databases, SaaS Applications, Cloud Storage, SDKs, and Streaming Services.
 * [Kiba ETL](http://www.kiba-etl.org) - A data processing & ETL framework for Ruby.
 * [LinkedPipes ETL](https://etl.linkedpipes.com) - Linked Data publishing and consumption ETL tool.


### PR DESCRIPTION
Adds [Duckle](https://github.com/SouravRoy-ETL/duckle) to the **Extract, transform, load (ETL)** section, alphabetically after Dataform and before Hevo.

Duckle is an open-source visual ETL/ELT studio that compiles a drag-and-drop canvas to DuckDB SQL, with 300+ connectors and a built-in MCP server.