### PR TITLE
Add metrics-petri

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Pipeline frameworks & libraries
 * [Martian](http://martian-lang.org/) - A language and framework for developing and executing complex computational pipelines.
 * [MD Studio](https://github.com/MD-Studio/MDStudio) - Microservice based workflow engine.
 * [MetaFlow](https://metaflow.org/) - Open-sourced framework from Netflix, for DAG generation for data scientists. Python and R API's.
+  * [metrics-petri](https://github.com/rotsl/metrics-petri) - Python pipeline for Petri dish colony segmentation and morphometric analysis of magnaporthe fungal growth experiments.
 * [Mistral](https://github.com/openstack/mistral) - Python based workflow engine by the Open Stack project.
 * [Moa](https://github.com/mfiers/Moa) - Lightweight workflows in bioinformatics.
 * [Nextflow](http://www.nextflow.io) - Flow-based computational toolkit for reproducible and scalable bioinformatics pipelines.


### PR DESCRIPTION
## Summary

This PR adds metrics-petri, a Python pipeline for Petri dish colony segmentation and morphometric analysis of magnaporthe fungal growth experiments.

It supports reproducible quantitative analysis of fungal colony growth image data, including use cases related to Magnaporthe oryzae research.

Project links:
- GitHub: https://github.com/rotsl/metrics-petri
- Documentation: https://rotsl.github.io/metrics-petri/
- PyPI: https://pypi.org/project/metrics-petri/