### PR TITLE
Add Nika (AI workflow engine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Pipeline frameworks & libraries
 * [Moa](https://github.com/mfiers/Moa) - Lightweight workflows in bioinformatics.
 * [Nextflow](http://www.nextflow.io) - Flow-based computational toolkit for reproducible and scalable bioinformatics pipelines.
 * [nFlow](https://github.com/NitorCreations/nFlow) - Embeddable JVM-based workflow engine with high availability, fault tolerance, and support for multiple databases. Additional libraries are provided for visualization and REST API.
+* [Nika](https://github.com/supernovae-st/nika) - Intent-as-code workflow engine for AI pipelines; YAML DAGs statically checked (schema, permits, cost floor) before execution, tamper-evident traces after.
 * [NiPype](https://github.com/nipy/nipype) - Workflows and interfaces for neuroimaging packages.
 * [OpenGE](https://github.com/adaptivegenome/openge) - Accelerated framework for manipulating and interpreting high-throughput sequencing data.
 * [Pachyderm](https://www.pachyderm.io/) - Distributed and reproducible data pipelining and data management, built on the container ecosystem.


### PR DESCRIPTION
Adds **Nika** to Pipeline frameworks & libraries (alphabetical).

Workflow engine for AI pipelines in a single Rust binary (AGPL-3.0): pipelines are `.nika.yaml` DAGs — validated statically (schema, permits, honest cost floor) before execution, with tamper-evident run traces for audit/replay.

Disclosure: I'm the author.
