### PR TITLE
Add Fallout to Build automation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Build automation tools
 ----------------------
 * [Bazel](http://bazel.io/) - Build software just as engineers do at Google.
 * [doit](https://github.com/pydoit/doit) - Highly generalized task-management and automation in Python.
+* [Fallout](https://github.com/Fallout-build/Fallout) - Build system for C#/.NET, where the build itself is a C# console app.
 * [Gradle](http://gradle.org/) - Unified cross platforms builds.
 * [Just](https://github.com/casey/just) - Command and recipe runner similar to Make, built in Rust.
 * [Make](https://www.gnu.org/software/make/) - The GNU Make build system.


### PR DESCRIPTION
Adds [Fallout](https://github.com/Fallout-build/Fallout) — a build automation system for C#/.NET where the build is itself a C# console app — to **Build automation tools**.

The section covers general-purpose build systems per language ecosystem (Bazel, Gradle, Scons for C/C++, Shake for Haskell) but has no .NET entry.

- MIT licensed.
- Placed alphabetically between `doit` and `Gradle`.
- Single suggestion, description one line and ends with a period.
- Searched the list and open PRs first — no existing or proposed entry.

Context: Fallout is the maintained hard-fork successor to NUKE.