### PR TITLE
Add Datanika to Extract, transform, load (ETL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Extract, transform, load (ETL)
 * [Bruin](https://github.com/bruin-data/bruin) - Data pipeline framework supporting SQL and Python in the same DAG. Built-in data quality assertions, cross-database lineage, and incremental processing. Targets data warehouses (BigQuery, Snowflake, Postgres, etc.).
 * [Cadence](https://github.com/uber/cadence) Distributed, scalable, durable, and highly available orchestration engine developed by Uber.
 * [Dataform](https://github.com/dataform-co/dataform) - Dataform is a framework for managing SQL based operations in your data warehouse.
+* [Datanika](https://datanika.io) - Self-hosted ELT platform combining dlt extract-and-load, dbt-core transforms and scheduling in one UI.
 * [Hevo](https://hevodata.com/integrations/pipeline/) - Hevo is a Fully Automated, No-code Data Pipeline Platform that supports 150+ ready-to-use integrations across Databases, SaaS Applications, Cloud Storage, SDKs, and Streaming Services.
 * [Kiba ETL](http://www.kiba-etl.org) - A data processing & ETL framework for Ruby.
 * [LinkedPipes ETL](https://etl.linkedpipes.com) - Linked Data publishing and consumption ETL tool.


### PR DESCRIPTION
Adds **Datanika** to *Extract, transform, load (ETL)*.

Datanika is an open-source (AGPL-3.0) ELT platform: it wires [dlt](https://dlthub.com) for
extract-and-load to [dbt-core](https://www.getdbt.com) for transforms, and puts a visual pipeline
builder, cron scheduling and run history around both. Self-hosted with a single `docker compose up`
— no Kubernetes.

- Site: https://datanika.io
- Source: https://github.com/datanika-io/datanika-core
- License: **AGPL-3.0** (noting it explicitly, since the guidelines ask contributors to check that
  the license is suitable)

Guidelines followed: one suggestion in this PR · `[RESOURCE](LINK) - DESCRIPTION.` format · ends with
a period · inserted alphabetically between *Dataform* and *Hevo* · searched the README first, and
neither Datanika nor a duplicate entry is present.

**Disclosure:** I maintain this project, and this PR was drafted with an AI coding assistant. The
entry's claims were checked against the repository before submitting. Happy to reword or drop it if
it is not a fit for the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01373MPoUkPZsAgHgGTBRiiS
