### PR TITLE
Add Renart to Pipeline Frameworks and Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Pipeline frameworks & libraries
 * [Redun](https://github.com/insitro/redun) - Yet another redundant workflow engine.
 * [Reflow](https://github.com/grailbio/reflow) - Language and runtime for distributed, incremental data processing in the cloud.
 * [Remake](https://github.com/richfitz/remake) - Make-like declarative workflows in R.
+* [Renart](https://github.com/renart-data/renart) - Local-first IDE for authoring and running SQL and Python data pipelines stored in Git.
 * [Rmake](http://physiology.med.cornell.edu/faculty/mason/lab/r-make/) - Wrapper for the creation of Makefiles, enabling massive parallelization.
 * [Rubra](https://github.com/bjpop/rubra) - Pipeline system for bioinformatics workflows.
 * [Ruffus](http://www.ruffus.org.uk) - Computation Pipeline library for Python.


### PR DESCRIPTION
Adds [Renart](https://github.com/renart-data/renart) alphabetically to Pipeline frameworks & libraries, after Remake.

Renart is a local-first IDE for authoring and running SQL and Python data pipelines stored in Git. Its pipeline authoring, dependency visualization, execution and scheduling workflows fit the existing workflow-tool category. It is Apache-2.0 licensed and currently in public alpha.

Disclosure: I'm the creator of Renart. This submission was prepared with AI assistance.

The addition follows the existing link/description format and ends with a period. I checked previous Renart suggestions and found no duplicate entry or issue/PR.
